### PR TITLE
eth0 address seems bad

### DIFF
--- a/vagrant_init_builder.sh
+++ b/vagrant_init_builder.sh
@@ -12,6 +12,7 @@ sudo truncate -s 40G /tmp/sparse-file.img
 # Initialize the Builders
 sudo \
   SERVICES_PRIVATE_IP="192.168.205.10" \
+  CIRCLE_PRIVATE_IP="192.168.205.11" \
   CIRCLE_BUILD_VOLUMES="/tmp/sparse-file.img" \
   CIRCLE_CONTAINER_MEMORY_LIMIT="1G" \
   CIRCLE_SECRET_PASSPHRASE='d3d662b598d773393f9d81fb6ff5b6cc571e555a' \


### PR DESCRIPTION
`Vagrantfile` assigns the builder the private ip `192.168.205.11` yet - and Vagrant/Virtualbox seems to make it be `eth1`.  In my local environment `eth0` gets assigned to `10.0.2.15` ip address.

For someone reason the traffic through `eth0` seems bad, but traffic through `eth1` (with the assigned ip address) seem fine.  Not obvious to me why exactly, but without this change, builders cannot actually provision containers.  I suspect it's something about the way Virtualbox manages network and the routing assigned to it but that's a wild guess...